### PR TITLE
捕获获取ExceptGroups时的异常

### DIFF
--- a/Dice/DiceConsole.cpp
+++ b/Dice/DiceConsole.cpp
@@ -311,7 +311,20 @@ void getDiceList()
 void getExceptGroup() {
 	std::string list;
 	if (Network::GET("shiki.stringempty.xyz", "/DiceCloud/except_group.json", 80, list))
-		json::parse(list, nullptr, false).get_to(ExceptGroups);
+	{
+		try
+		{
+			json::parse(list, nullptr, false).get_to(ExceptGroups);
+		}
+		catch (...)
+		{
+			console.log("解析ExceptGroups时遇到错误！", 1, printSTNow());
+		}
+	}
+	else
+	{
+		console.log("获取ExceptGroups时遇到错误！", 1, printSTNow());
+	}
 }
 
 


### PR DESCRIPTION
捕获获取ExceptGroups时的异常，该过程原本会在服务器出现问题时产生报错。